### PR TITLE
Added test job in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,41 +117,66 @@ jobs:
           status: ${{ job.status }}
           timestamp: ${{ steps.slack.outputs.slack-timestamp }}
 
-test:
+  test:
     runs-on: ubuntu-latest
-    needs: [lint]
     steps:
       - name: Check out
         uses: actions/checkout@v4
 
-      - name: Install ImageMagick Dependencies
-        run: |
-          #Install dependencies required by tests/tests.sh (ImageMagick/PerlMagick)
-          sudo apt-get update
-          sudo apt-get install -y imagemagick libimage-magick-perl
+      - name: Send Slack notification
+        uses: codedsolar/slack-action@v1
+        if: ${{ github.event_name != 'pull_request' }}
+        id: slack
+        with:
+          fields: |
+            {STATUS}
+            {REF}
+            Testing: Checking...
+          status: in-progress
 
       - name: Run tests
-        id: run_tests
-        # The '|| true' allows the workflow to continue to the artifact upload even if tests fail, so that we can save results.
-        run: tests/tests.sh || true
+        run: |
+          docker pull dstmodders/imagemagick:latest
+          docker run \
+            -u "$(id -u):$(id -g)" \
+            -v './tests:/tests:rw' \
+            -v './tests-latest-results:/tmp/result:rw' \
+            -w /tests/ \
+            dstmodders/imagemagick:latest \
+            /bin/sh -c './tests.sh; mv ./result/* /tmp/result/'
 
-      - name: Upload Test Results artifact
+          docker pull dstmodders/imagemagick:legacy
+          docker run \
+            -u "$(id -u):$(id -g)" \
+            -v './tests:/tests:rw' \
+            -v './tests-legacy-results:/tmp/result:rw' \
+            -w /tests/ \
+            dstmodders/imagemagick:legacy \
+            /bin/sh -c './tests.sh; mv ./result/* /tmp/result/'
+
+      - name: Upload latest test results
         uses: actions/upload-artifact@v4
-        # This condition ensures the artifact is always uploaded, even if the tests fail.
         if: always()
         with:
-          name: test-results-${{ github.run_id }}
-          path: tests/result/
+          name: tests-latest-results-${{ github.run_id }}
+          path: ./tests-latest-results
           retention-days: 7
 
-      - name: Update Slack with Test Status and Link
+      - name: Upload legacy test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: tests-legacy-results-${{ github.run_id }}
+          path: ./tests-legacy-results
+          retention-days: 7
+
+      - name: Update Slack notification
         uses: codedsolar/slack-action@v1
         if: ${{ github.event_name != 'pull_request' && always() }}
         with:
           fields: |
             {STATUS}
             {REF}
-            Test Status: ${{ job.status }}
-            Test Results Artifact: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} | View Artifacts>
+            Testing: Completed
           status: ${{ job.status }}
           timestamp: ${{ steps.slack.outputs.slack-timestamp }}

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -8,9 +8,7 @@ readonly BASE_DIR
 readonly IMAGE_RECT_SIZE
 
 create() {
-  IMAGEMAGICK_VERSION=${IMAGEMAGICK_VERSION:-$(convert -version 2>/dev/null | head -n 1 | sed 's/^.*Version: ImageMagick \([0-9]\).*$/\1/')}
-
-  if [ "$IMAGEMAGICK_VERSION" = '6' ]; then
+  if [ "$(printf '%s' "$IMAGEMAGICK_VERSION" | cut -c 1)" -eq '6' ]; then
     # shellcheck disable=SC2068
     convert $@
   else


### PR DESCRIPTION
Closes #19 
-> Added test job in CI
-> Modified ci.yml slightly becaue it was causing parsing error when tests.sh script ran.

- [x] Add the test job in .github/workflows/ci.yml that runs the tests/tests.sh script.
- [x] Add support for uploading tests/result/ directory as artifacts.
- [x] Add support for sending a Slack notification with the uploaded artifacts, either embedded in the message or as a download link (optional).  ->  ( This needs to be tested once it's merged.)

<img width="1920" height="1080" alt="Screenshot_2025-10-30_18_08_36" src="https://github.com/user-attachments/assets/ece89620-2282-4693-80f6-a5c7ef2b7c8e" />
<img width="1920" height="1080" alt="Screenshot_2025-10-30_18_08_55" src="https://github.com/user-attachments/assets/1f41e74e-5fb9-426e-bee9-da9173a174bb" />
