### PR TITLE
ci: enable CI on pull_request for develop and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,18 @@
 name: CI
 
+permissions:
+  contents: read
+
+concurrency:
+  group: CI-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
+    branches:
+      - develop
+      - main
+  pull_request:
     branches:
       - develop
       - main
@@ -75,7 +86,6 @@ jobs:
           latest_debian_issues="$(echo '${{ steps.hadolint-latest-debian.outputs.results }}' | sed '/^$/d' | sed '$!N; /^\n$/D' | wc -l)"
           legacy_alpine_issues="$(echo '${{ steps.hadolint-legacy-alpine.outputs.results }}' | sed '/^$/d' | sed '$!N; /^\n$/D' | wc -l)"
           legacy_debian_issues="$(echo '${{ steps.hadolint-legacy-debian.outputs.results }}' | sed '/^$/d' | sed '$!N; /^\n$/D' | wc -l)"
-
           {
             echo "latest-alpine-issues=$latest_alpine_issues"
             echo "latest-debian-issues=$latest_debian_issues"
@@ -91,14 +101,12 @@ jobs:
           hadolint_legacy_debian_issues="${{ steps.hadolint.outputs.legacy-debian-issues }}"
           hadolint_issues="${{ steps.hadolint.outputs.issues }}"
           prettier_issues="${{ steps.prettier.outputs.issues }}"
-
           echo "Hadolint issues (latest Alpine): $hadolint_latest_alpine_issues"
           echo "Hadolint issues (latest Debian): $hadolint_latest_debian_issues"
           echo "Hadolint issues (legacy Alpine): $hadolint_legacy_alpine_issues"
           echo "Hadolint issues (legacy Debian): $hadolint_legacy_debian_issues"
           echo "Total Hadolint issues: $hadolint_issues"
           echo "Total Prettier issues: $prettier_issues"
-
           exit_code=1
           if [ "$prettier_issues" = '0' ] && [ "$hadolint_issues" = '0' ]; then
             exit_code=0
@@ -118,11 +126,11 @@ jobs:
           timestamp: ${{ steps.slack.outputs.slack-timestamp }}
 
   test:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out
         uses: actions/checkout@v4
-
       - name: Send Slack notification
         uses: codedsolar/slack-action@v1
         if: ${{ github.event_name != 'pull_request' }}
@@ -133,13 +141,10 @@ jobs:
             {REF}
             Testing: Checking...
           status: in-progress
-
       - name: Run tests
         run: |
           mkdir -p ./tests/result/ ./tests-latest-results/ ./tests-legacy-results/
           sudo chown -R 1000:1000 ./tests/ ./tests-latest-results/ ./tests-legacy-results/
-
-          # ImageMagick 7
           docker pull dstmodders/imagemagick:latest
           docker run \
             -v './tests:/tests:rw' \
@@ -147,8 +152,6 @@ jobs:
             -w /tests/ \
             dstmodders/imagemagick:latest \
             /bin/sh -c './tests.sh; mv ./result/* /tmp/result/'
-
-          # ImageMagick 6
           docker pull dstmodders/imagemagick:legacy
           docker run \
             -v './tests:/tests:rw' \
@@ -156,7 +159,6 @@ jobs:
             -w /tests/ \
             dstmodders/imagemagick:legacy \
             /bin/sh -c './tests.sh; mv ./result/* /tmp/result/'
-
       - name: Upload latest test results
         uses: actions/upload-artifact@v4
         if: always()
@@ -164,7 +166,6 @@ jobs:
           name: tests-latest-results-${{ github.run_id }}
           path: ./tests-latest-results
           retention-days: 7
-
       - name: Upload legacy test results
         uses: actions/upload-artifact@v4
         if: always()
@@ -172,7 +173,6 @@ jobs:
           name: tests-legacy-results-${{ github.run_id }}
           path: ./tests-legacy-results
           retention-days: 7
-
       - name: Update Slack notification
         uses: codedsolar/slack-action@v1
         if: ${{ github.event_name != 'pull_request' && always() }}


### PR DESCRIPTION
### Summary
This PR enables the CI workflow to run automatically on pull requests targeting the `develop` and `main` branches.

### Changes
- Added `pull_request` trigger for `develop` and `main` in `.github/workflows/ci.yml`
- Added `permissions: read` and `concurrency` block for better safety and efficiency
- Ensures PRs also go through CI validation before merging

### Motivation
Allows maintainers and contributors to see CI results directly on pull requests, improving review speed and preventing broken code from being merged.

### Type of change
- [x] CI/CD improvement
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / Cleanup

### Checklist
- [x] Workflow syntax verified
- [x] CI triggers correctly for PRs
- [x] No breaking changes introduced
