### PR TITLE
Fix issue with generation of latest tags in bump-supported-tags script

### DIFF
--- a/bin/bump-supported-tags.sh
+++ b/bin/bump-supported-tags.sh
@@ -109,7 +109,7 @@ print_latest_tags() {
       latest="$(jq -r ".latest | .[${key}] | .latest" <<< "${JSON}")"
 
       tag_dist="${dist}"
-      tag_full="${version-${dist}}"
+      tag_full="${version}-${dist}"
       tag_version="${version}"
 
       tags=''


### PR DESCRIPTION
Fixes #36.