### PR TITLE
Add explicitly code linting and formatting tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,13 @@ jobs:
           status: in-progress
       - name: Enable corepack
         run: corepack enable
-      - name: Install Prettier
-        run: yarn global add prettier
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
       - name: Lint using Prettier
-        run: prettier --check . || true
+        run: pnpm exec prettier --check . || true
       - name: Output Prettier results
         id: prettier
-        run: echo "issues=$(prettier --list-different . | wc -l)" >> "$GITHUB_OUTPUT"
+        run: echo "issues=$(pnpm exec prettier --list-different . | wc -l)" >> "$GITHUB_OUTPUT"
       - name: Lint using Hadolint (latest Alpine)
         uses: hadolint/hadolint-action@v3.3.0
         id: hadolint-latest-alpine

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.idea/
-.vscode/
-tests/perlmagick/demo.pam
-tests/result/
+/.idea/
+/.vscode/
+/node_modules/
+/tests/perlmagick/demo.pam
+/tests/result/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "$schema": "https://json.schemastore.org/prettierrc",
   "singleQuote": true,
   "trailingComma": "all",
-  "endOfLine": "lf"
+  "endOfLine": "lf",
+  "plugins": ["prettier-plugin-sh"]
 }

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -32,7 +32,7 @@ declare -A LEGACY_IMAGES=(
   ['legacy/debian']='legacy-debian'
 )
 
-if docker buildx version >/dev/null 2>&1; then
+if docker buildx version > /dev/null 2>&1; then
   BUILDX_AVAILABLE=1
 fi
 
@@ -178,21 +178,21 @@ cd "${BASE_DIR}/.." || exit 1
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
-    -b=*|--build-cpus=*)
+    -b=* | --build-cpus=*)
       set_flag_build_cpus "${1#*=}"
       ;;
-    -b|--build-cpus)
+    -b | --build-cpus)
       set_flag_build_cpus "${2:-}"
       shift
       ;;
-    -p=*|--progress=*)
+    -p=* | --progress=*)
       set_flag_progress "${1#*=}"
       ;;
-    -p|--progress)
+    -p | --progress)
       set_flag_progress "${2:-}"
       shift
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;
@@ -217,12 +217,12 @@ done
 readonly BUILD_SET
 readonly FLAG_PROGRESS
 
-if ! which docker >/dev/null 2>&1; then
+if ! which docker > /dev/null 2>&1; then
   print_error 'Docker CLI is not installed'
   exit 1
 fi
 
-if ! docker info >/dev/null 2>&1; then
+if ! docker info > /dev/null 2>&1; then
   print_error 'Docker daemon is not running'
   exit 1
 fi

--- a/bin/bump-imagemagick.sh
+++ b/bin/bump-imagemagick.sh
@@ -122,13 +122,13 @@ new_version=''
 while [ $# -gt 0 ]; do
   key="$1"
   case "${key}" in
-    latest|legacy)
+    latest | legacy)
       name="${key}"
       ;;
-    -c|--commit)
+    -c | --commit)
       FLAG_COMMIT=1
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;
@@ -151,8 +151,14 @@ if [ -z "${name}" ]; then
   options=('latest' 'legacy')
   select opt in "${options[@]}"; do
     case "${opt}" in
-      latest) name='latest'; break ;;
-      legacy) name='legacy'; break ;;
+      latest)
+        name='latest'
+        break
+        ;;
+      legacy)
+        name='legacy'
+        break
+        ;;
       *) print_error 'unrecognized option (choose number 1 or 2)' ;;
     esac
   done

--- a/bin/bump-packages.sh
+++ b/bin/bump-packages.sh
@@ -81,10 +81,10 @@ print_title() {
 get_packages_from_dockerfile() {
   local dockerfile="$1"
   sed -n \
-      -e '/apk add --no-cache/,/&&/p' \
-      -e '/apk add --no-cache --virtual/,/&&/p' \
-      -e '/apt-get install -y --no-install-recommends/,/&&/p' \
-      "${dockerfile}" \
+    -e '/apk add --no-cache/,/&&/p' \
+    -e '/apk add --no-cache --virtual/,/&&/p' \
+    -e '/apt-get install -y --no-install-recommends/,/&&/p' \
+    "${dockerfile}" \
     | sed -E ':a;N;$!ba;s/\\\n/ /g' \
     | grep -oE '([a-zA-Z0-9+.]+(-[a-zA-Z0-9+.]+)*=[^[:space:]]+)' \
     | sed "s/'//g" \
@@ -265,17 +265,17 @@ cd "${BASE_DIR}/.." || exit 1
 while [ $# -gt 0 ]; do
   key="$1"
   case "${key}" in
-    -c|--commit)
+    -c | --commit)
       FLAG_COMMIT=1
       ;;
-    -d|--dry-run)
+    -d | --dry-run)
       FLAG_DRY_RUN=1
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;
-    -l|--list)
+    -l | --list)
       FLAG_LIST=1
       ;;
     -*)

--- a/bin/bump-supported-tags.sh
+++ b/bin/bump-supported-tags.sh
@@ -172,13 +172,13 @@ cd "${BASE_DIR}/.." || exit 1
 while [ $# -gt 0 ]; do
   key="$1"
   case "${key}" in
-    -c|--commit)
+    -c | --commit)
       FLAG_COMMIT=1
       ;;
-    -d|--dry-run)
+    -d | --dry-run)
       FLAG_DRY_RUN=1
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;

--- a/latest/alpine/Dockerfile
+++ b/latest/alpine/Dockerfile
@@ -56,7 +56,7 @@ RUN addgroup -g 1000 imagemagick \
     /tmp/ImageMagick/ \
   && cd /tmp/ImageMagick/ \
   && ./configure --with-perl --with-png \
-  && : "${BUILD_CPUS:=$(( $(nproc) > 1 ? $(nproc) / 2 : 1 ))}" \
+  && : "${BUILD_CPUS:=$(($(nproc) > 1 ? $(nproc) / 2 : 1))}" \
   && echo "BUILD_CPUS=${BUILD_CPUS}" \
   && echo "make -j${BUILD_CPUS}" \
   && make -j"${BUILD_CPUS}" \

--- a/latest/debian/Dockerfile
+++ b/latest/debian/Dockerfile
@@ -46,7 +46,7 @@ RUN groupadd --gid 1000 imagemagick \
     /tmp/ImageMagick/ \
   && cd /tmp/ImageMagick/ \
   && ./configure --with-perl --with-png \
-  && : "${BUILD_CPUS:=$(( $(nproc) > 1 ? $(nproc) / 2 : 1 ))}" \
+  && : "${BUILD_CPUS:=$(($(nproc) > 1 ? $(nproc) / 2 : 1))}" \
   && echo "BUILD_CPUS=${BUILD_CPUS}" \
   && echo "make -j${BUILD_CPUS}" \
   && make -j"${BUILD_CPUS}" \

--- a/legacy/alpine/Dockerfile
+++ b/legacy/alpine/Dockerfile
@@ -56,7 +56,7 @@ RUN addgroup -g 1000 imagemagick \
     /tmp/ImageMagick/ \
   && cd /tmp/ImageMagick/ \
   && ./configure --with-perl --with-png \
-  && : "${BUILD_CPUS:=$(( $(nproc) > 1 ? $(nproc) / 2 : 1 ))}" \
+  && : "${BUILD_CPUS:=$(($(nproc) > 1 ? $(nproc) / 2 : 1))}" \
   && echo "BUILD_CPUS=${BUILD_CPUS}" \
   && echo "make -j${BUILD_CPUS}" \
   && make -j"${BUILD_CPUS}" \

--- a/legacy/debian/Dockerfile
+++ b/legacy/debian/Dockerfile
@@ -46,7 +46,7 @@ RUN groupadd --gid 1000 imagemagick \
     /tmp/ImageMagick/ \
   && cd /tmp/ImageMagick/ \
   && ./configure --with-perl --with-png \
-  && : "${BUILD_CPUS:=$(( $(nproc) > 1 ? $(nproc) / 2 : 1 ))}" \
+  && : "${BUILD_CPUS:=$(($(nproc) > 1 ? $(nproc) / 2 : 1))}" \
   && echo "BUILD_CPUS=${BUILD_CPUS}" \
   && echo "make -j${BUILD_CPUS}" \
   && make -j"${BUILD_CPUS}" \

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "docker-imagemagick",
+  "private": true,
+  "scripts": {
+    "deduplicate": "pnpm dedupe",
+    "format": "run-s format:sort-package-json format:prettier",
+    "format:prettier": "prettier --write .",
+    "format:sort-package-json": "sort-package-json",
+    "lint": "run-s lint:sort-package-json lint:prettier lint:hadolint",
+    "lint:hadolint": "hadolint latest/alpine/Dockerfile latest/debian/Dockerfile legacy/alpine/Dockerfile legacy/debian/Dockerfile",
+    "lint:prettier": "prettier --check .",
+    "lint:sort-package-json": "sort-package-json --check"
+  },
+  "devDependencies": {
+    "hadolint": "^0.4.1",
+    "npm-run-all2": "^9.0.2",
+    "prettier": "^3.9.6",
+    "prettier-plugin-sh": "^0.19.0",
+    "sort-package-json": "^4.0.0"
+  },
+  "packageManager": "pnpm@11.17.0"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,405 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      hadolint:
+        specifier: ^0.4.1
+        version: 0.4.2
+      npm-run-all2:
+        specifier: ^9.0.2
+        version: 9.0.2
+      prettier:
+        specifier: ^3.9.6
+        version: 3.9.6
+      prettier-plugin-sh:
+        specifier: ^0.19.0
+        version: 0.19.0(prettier@3.9.6)
+      sort-package-json:
+        specifier: ^4.0.0
+        version: 4.0.0
+
+packages:
+
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
+
+  '@reteps/dockerfmt-darwin-arm64@0.5.4':
+    resolution: {integrity: sha512-urMqV+dQyvVI8/WrXwClX9e1PEyS35wFdwJjpZYmL09AkV4Io5U1oam8UBKK7jZk0+YsdF88ay6e86Kn6DIyQg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@reteps/dockerfmt-darwin-x64@0.5.4':
+    resolution: {integrity: sha512-fJORy6DFxbgDiMqxpLTPZlb5KUY0Vq0iR4NGnyKnuYZ9LdZUS508DK2kt/AJ87/jIKNV1qRG0JXG1Tc6xdvWjw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@reteps/dockerfmt-linux-arm64@0.5.4':
+    resolution: {integrity: sha512-6pVakO06eXtDuvxy1Dnjs/gQyUoGGycle8PRSt5IFRwLi/AVaOQwfkfmW0WP8VH9wNUeti6BfJ3ksTn2G+XMxg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@reteps/dockerfmt-linux-x64@0.5.4':
+    resolution: {integrity: sha512-OD6SIlUV1D4TgJoTui3FMBAZsGbTSPYsiT0BKhD6jMUcJb3GpFTa7dY9rL8rP9FUqfL7OTHVUGUOL4Rh64Olog==}
+    cpu: [x64]
+    os: [linux]
+
+  '@reteps/dockerfmt@0.5.4':
+    resolution: {integrity: sha512-HEGgXVVOb+JtGUSSzXl/XPKFIZjMDTUoHarCjaQdkY+cb5M9K/O3b5xm+x0IPIk3SfHurbc0bSgcFsQlzjitxA==}
+    engines: {node: ^v12.20.0 || ^14.13.0 || >=16.0.0}
+    hasBin: true
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  detect-indent@7.0.2:
+    resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
+    engines: {node: '>=12.20'}
+
+  detect-newline@4.0.1:
+    resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  git-hooks-list@4.2.1:
+    resolution: {integrity: sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==}
+
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  hadolint@0.4.2:
+    resolution: {integrity: sha512-V1ZhPiiY2LAnFa9NPMR+TS8yi7X9dAnpHvtBamW3QSUdQVDtQ77vW+YufkSjFaF5rT3FZ67ryZLMiVNqRfwc9g==}
+    engines: {node: '>=21.0.0'}
+    hasBin: true
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
+
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
+
+  json-parse-even-better-errors@6.0.0:
+    resolution: {integrity: sha512-2/8adwnK1/+Fdjyts4r6wSpfANWw8zdNhU9U/Llk59c6O+DjSisPWPykwoL8gZmocP9Dy64S7oie2g+Mia123A==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
+  memorystream@0.3.1:
+    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
+    engines: {node: '>= 0.10.0'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  npm-normalize-package-bin@6.0.0:
+    resolution: {integrity: sha512-tdt4aFn9QamlhdN3HV2D2ccpBwO5/fyjjbXUxYA6uBjyekMZcZvDq0aSj9t5Jo+tih6AYFnt/cuIRn9013e0Uw==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  npm-run-all2@9.0.2:
+    resolution: {integrity: sha512-+dd4SO2jAlLE06OzmJKzIe6QvvjXezcbmobnh8usR0a8BzQCABTdqTXqVPji0ICOhSQpIIrkGd7IzNl5iDaRSA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0, npm: '>= 10'}
+    hasBin: true
+
+  p-await-all@0.1.2:
+    resolution: {integrity: sha512-OvNSlOYm5dp2QzmP+aZez6rFY3F8KjOAlwj8jTBNyM01DYx53Eo2jR3lZ2+RPFbTXP+rnoBsm+cr/WPcCnLkMw==}
+    engines: {node: '>=16.0.0'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  pidtree@1.0.0:
+    resolution: {integrity: sha512-avfAvjB9Dd0wdj3rjJX//yS+G79OO0KrS5pJHFJENjYGX6N4SMgEDBBI/yFy0lloOYSaC6XQxzpOAMPfSYFV/Q==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  prettier-plugin-sh@0.19.0:
+    resolution: {integrity: sha512-39VXFZH/cOGtcuu8aeSvqp/hhwomOR4QroZUj+jBz2cNb3os9s0sqFZSNlYts6jdtLLDU7D2YT3Z1+abtb7adQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      prettier: ^3.6.0
+
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  read-package-json-fast@6.0.0:
+    resolution: {integrity: sha512-PNaGjoCnw9DBA2Kl8D+8po957z778q/HOPuY2u3Bkw/JO3eC8MDx7jn/PgMtSgpcBbs+6UOjDbwReGpXmRvs0g==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sh-syntax@0.6.0:
+    resolution: {integrity: sha512-52VK6z/cdZHv7UURjIcwfBUQZrAhIEEe0bY4lrkfypjnFIKsDZdD3Uaz/dBiw/sF8BeX0Mssv140s8EnrsJ9dQ==}
+    engines: {node: '>=16.0.0'}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
+    engines: {node: '>= 0.4'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  sort-object-keys@2.1.0:
+    resolution: {integrity: sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g==}
+
+  sort-package-json@4.0.0:
+    resolution: {integrity: sha512-6aYOlYI9AWioZ+rzu+4zKLmoFqJP0/fHDxrd7X04yqEibikY+5YVF0EYlyGn4v6X2PJY7yAUWV7oeP+i5rOm/g==}
+    engines: {node: '>=22'}
+    hasBin: true
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  which@7.0.0:
+    resolution: {integrity: sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    hasBin: true
+
+snapshots:
+
+  '@isaacs/cliui@9.0.0': {}
+
+  '@reteps/dockerfmt-darwin-arm64@0.5.4':
+    optional: true
+
+  '@reteps/dockerfmt-darwin-x64@0.5.4':
+    optional: true
+
+  '@reteps/dockerfmt-linux-arm64@0.5.4':
+    optional: true
+
+  '@reteps/dockerfmt-linux-x64@0.5.4':
+    optional: true
+
+  '@reteps/dockerfmt@0.5.4':
+    optionalDependencies:
+      '@reteps/dockerfmt-darwin-arm64': 0.5.4
+      '@reteps/dockerfmt-darwin-x64': 0.5.4
+      '@reteps/dockerfmt-linux-arm64': 0.5.4
+      '@reteps/dockerfmt-linux-x64': 0.5.4
+
+  ansi-styles@6.2.3: {}
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@5.0.8:
+    dependencies:
+      balanced-match: 4.0.4
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  detect-indent@7.0.2: {}
+
+  detect-newline@4.0.1: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  git-hooks-list@4.2.1: {}
+
+  glob@11.1.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
+
+  hadolint@0.4.2:
+    dependencies:
+      glob: 11.1.0
+      p-await-all: 0.1.2
+
+  is-plain-obj@4.1.0: {}
+
+  isexe@2.0.0: {}
+
+  isexe@4.0.0: {}
+
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
+
+  json-parse-even-better-errors@6.0.0: {}
+
+  lru-cache@11.5.2: {}
+
+  memorystream@0.3.1: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.8
+
+  minipass@7.1.3: {}
+
+  npm-normalize-package-bin@6.0.0: {}
+
+  npm-run-all2@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      cross-spawn: 7.0.6
+      memorystream: 0.3.1
+      picomatch: 4.0.5
+      pidtree: 1.0.0
+      read-package-json-fast: 6.0.0
+      shell-quote: 1.10.0
+      which: 7.0.0
+
+  p-await-all@0.1.2: {}
+
+  package-json-from-dist@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
+
+  picomatch@4.0.5: {}
+
+  pidtree@1.0.0: {}
+
+  prettier-plugin-sh@0.19.0(prettier@3.9.6):
+    dependencies:
+      '@reteps/dockerfmt': 0.5.4
+      prettier: 3.9.6
+      sh-syntax: 0.6.0
+
+  prettier@3.9.6: {}
+
+  read-package-json-fast@6.0.0:
+    dependencies:
+      json-parse-even-better-errors: 6.0.0
+      npm-normalize-package-bin: 6.0.0
+
+  semver@7.8.5: {}
+
+  sh-syntax@0.6.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  shell-quote@1.10.0: {}
+
+  signal-exit@4.1.0: {}
+
+  sort-object-keys@2.1.0: {}
+
+  sort-package-json@4.0.0:
+    dependencies:
+      detect-indent: 7.0.2
+      detect-newline: 4.0.1
+      git-hooks-list: 4.2.1
+      is-plain-obj: 4.1.0
+      semver: 7.8.5
+      sort-object-keys: 2.1.0
+      tinyglobby: 0.2.17
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  which@7.0.0:
+    dependencies:
+      isexe: 4.0.0


### PR DESCRIPTION
1. Add `package.json` with `hadolint`, `npm-run-all2`, `prettier`, `prettier-plugin-sh`, `sort-package-json`
2. Add `pnpm` as the package manager
3. Add `.prettierignore` to exclude `pnpm-lock.yaml`
4. Add `prettier-plugin-sh` plugin to `.prettierrc`
5. Add `pnpm run format` (sort-package-json, prettier)
6. Add `pnpm run lint` (sort-package-json --check, prettier --check, hadolint)
7. Prefix `.gitignore` paths with `/` (best practices)
8. Fix code formatting issues

Closes #54.