### PR TITLE
Remove max-parallel limit for image builds in build GHA workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,6 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
       matrix:
         image: ${{ fromJSON(needs.prepare.outputs.legacy) }}
     steps:
@@ -117,7 +116,6 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
       matrix:
         image: ${{ fromJSON(needs.prepare.outputs.latest) }}
     steps:


### PR DESCRIPTION
Remove "`max-parallel: 1`" from the `legacy-build` and `latest-build` jobs, so matrix entries build concurrently.

Closes #58.