### PR TITLE
Add Dependabot to keep dependencies up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: develop
+    groups:
+      github-actions:
+        patterns: ['*']
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: develop
+    groups:
+      npm-development:
+        dependency-type: development


### PR DESCRIPTION
Add a weekly [Dependabot](https://github.com/dependabot) schedule for the `github-actions` and `npm` ecosystems, grouping [GitHub Actions](https://github.com/features/actions) updates and `npm` development dependency updates.

Closes #70.